### PR TITLE
Add ticket for Gemini streaming/chat support

### DIFF
--- a/open-tickets/042-gemini-image-understanding-integration.md
+++ b/open-tickets/042-gemini-image-understanding-integration.md
@@ -1,0 +1,15 @@
+# Integrate Gemini Image Understanding
+
+**Created**: 2025-06-10
+**Priority**: Medium
+**Component**: AI Integration
+
+## Description
+Add support for Gemini's image understanding features so workflows can analyze and extract information from uploaded images. This includes captioning, object detection, and segmentation. Configuration should be handled via `workflow.json`.
+
+## Tasks
+- [ ] Update `genkit` configuration to allow image inputs
+- [ ] Add optional image understanding settings in workflow JSON
+- [ ] Create UI components for uploading and previewing images
+- [ ] Display bounding boxes or segmentation results when available
+- [ ] Document how to enable image understanding in workflows

--- a/open-tickets/043-gemini-document-understanding-support.md
+++ b/open-tickets/043-gemini-document-understanding-support.md
@@ -1,0 +1,15 @@
+# Add Gemini Document Understanding Support
+
+**Created**: 2025-06-10
+**Priority**: Medium
+**Component**: AI Integration
+
+## Description
+Enable processing of PDF and other document formats using Gemini's document understanding capability. Workflows should specify document inputs and options in `workflow.json`.
+
+## Tasks
+- [ ] Extend stage configuration to accept document files
+- [ ] Use Gemini Files API for large or reusable documents
+- [ ] Provide UI elements for document upload and progress
+- [ ] Surface extracted text or metadata in stage output
+- [ ] Update documentation with usage examples

--- a/open-tickets/044-gemini-long-context-support.md
+++ b/open-tickets/044-gemini-long-context-support.md
@@ -1,0 +1,15 @@
+# Implement Gemini Long Context Support
+
+**Created**: 2025-06-10
+**Priority**: Medium
+**Component**: AI Integration
+
+## Description
+Support Gemini models with long context windows so workflows can process large amounts of text or code. Make context window settings configurable in `workflow.json`.
+
+## Tasks
+- [ ] Allow workflows to specify model version and context size
+- [ ] Add context caching mechanism for repeated prompts
+- [ ] Update AI stage execution to handle long inputs efficiently
+- [ ] Expose long-context settings in the wizard UI
+- [ ] Document best practices for using long context

--- a/open-tickets/045-gemini-thinking-mode.md
+++ b/open-tickets/045-gemini-thinking-mode.md
@@ -1,0 +1,15 @@
+# Enable Gemini Thinking Mode
+
+**Created**: 2025-06-10
+**Priority**: Low
+**Component**: AI Integration
+
+## Description
+Expose Gemini's thinking features so workflows can request thought summaries and configure thinking budgets. All parameters should be stored in `workflow.json`.
+
+## Tasks
+- [ ] Update genkit configuration to include `thinkingConfig`
+- [ ] Allow workflows to specify thinking budgets per stage
+- [ ] Display thought summaries in the UI when available
+- [ ] Handle pricing implications for thinking tokens
+- [ ] Update documentation with usage guidelines

--- a/open-tickets/046-gemini-function-calling.md
+++ b/open-tickets/046-gemini-function-calling.md
@@ -1,0 +1,15 @@
+# Integrate Gemini Function Calling
+
+**Created**: 2025-06-10
+**Priority**: Medium
+**Component**: AI Integration
+
+## Description
+Allow workflows to declare and use function calls through Gemini. Function declarations and calling modes should be defined in `workflow.json` for each stage.
+
+## Tasks
+- [ ] Add support for function declarations in workflow JSON
+- [ ] Execute model-suggested function calls and feed results back
+- [ ] Provide UI feedback when functions are invoked
+- [ ] Handle errors and retries for failed function calls
+- [ ] Document sample workflow configuration

--- a/open-tickets/047-gemini-code-execution.md
+++ b/open-tickets/047-gemini-code-execution.md
@@ -1,0 +1,15 @@
+# Add Gemini Code Execution Capability
+
+**Created**: 2025-06-10
+**Priority**: Medium
+**Component**: AI Integration
+
+## Description
+Integrate Gemini's code execution tool so workflows can run generated Python code and capture outputs. Configuration options should live in `workflow.json`.
+
+## Tasks
+- [ ] Enable code execution tool in genkit setup
+- [ ] Support file inputs and Matplotlib output images
+- [ ] Stream execution results back into stage output
+- [ ] Limit runtime and handle execution errors gracefully
+- [ ] Document how to enable code execution in workflows

--- a/open-tickets/048-gemini-files-api-integration.md
+++ b/open-tickets/048-gemini-files-api-integration.md
@@ -1,0 +1,15 @@
+# Support Gemini Files API for Large Inputs
+
+**Created**: 2025-06-10
+**Priority**: Low
+**Component**: AI Integration
+
+## Description
+Implement the Gemini Files API to handle large files or reusable assets in workflows. Stages should reference uploaded file IDs in `workflow.json`.
+
+## Tasks
+- [ ] Add API calls to upload and manage files
+- [ ] Allow stages to reference `createPartFromUri` file IDs
+- [ ] Provide UI feedback for upload progress and status
+- [ ] Ensure uploaded files are cached and reused when possible
+- [ ] Document file management within workflows

--- a/open-tickets/049-gemini-streaming-and-chat-support.md
+++ b/open-tickets/049-gemini-streaming-and-chat-support.md
@@ -1,0 +1,15 @@
+# Add Gemini Streaming and Chat Support
+
+**Created**: 2025-06-10
+**Priority**: Medium
+**Component**: AI Integration
+
+## Description
+Enable streaming responses and multi-turn chat capabilities in our workflows. This includes handling system instructions and chat history, all configurable in `workflow.json`.
+
+## Tasks
+- [ ] Update Genkit configuration to allow streaming token output
+- [ ] Persist conversation history per workflow stage
+- [ ] Add `systemInstructions` and `chatEnabled` options to workflow JSON
+- [ ] Display streaming progress and chat transcripts in the UI
+- [ ] Document streaming and chat setup for workflows


### PR DESCRIPTION
## Summary
- create ticket for Gemini streaming and chat support
- document Gemini features from docs, including image understanding, document understanding, long context, thinking mode, function calling, code execution, and Files API

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68487b75a8f083298842ef7893519d18